### PR TITLE
Rename FileBackend to FileCargo

### DIFF
--- a/lib/cargo_client.dart
+++ b/lib/cargo_client.dart
@@ -13,4 +13,3 @@ part 'src/client/storage_impl.dart';
 part 'src/client/memory_impl.dart';
 part 'src/client/cargo_mode.dart';
 part 'src/client/indexdb_impl.dart';
-

--- a/lib/cargo_server.dart
+++ b/lib/cargo_server.dart
@@ -11,4 +11,3 @@ part 'src/server/cargo.dart';
 part 'src/server/cargo_mode.dart';
 part 'src/server/file_impl.dart';
 part 'src/server/memory_impl.dart';
-

--- a/lib/src/cargo.dart
+++ b/lib/src/cargo.dart
@@ -11,7 +11,7 @@ abstract class CargoBase {
 
   /// Set/update an item synchronously
   void setItem(String key, data);
-  
+
   /// Add item synchronously
   void add(String key, data);
 
@@ -28,17 +28,16 @@ abstract class CargoBase {
     setItem(key, value);
   }
 
-  dynamic operator [](String key){
+  dynamic operator [](String key) {
     return getItemSync(key);
   }
-  
+
   Map export();
-  
+
   CargoBase copyTo(CargoBase storage) {
-      this.export().forEach((key, value) => storage.add(key, value));
-      return storage;
+    this.export().forEach((key, value) => storage.add(key, value));
+    return storage;
   }
 
   Future start() => _completer.future;
 }
-

--- a/lib/src/client/cargo.dart
+++ b/lib/src/client/cargo.dart
@@ -7,23 +7,22 @@ abstract class Cargo extends CargoBase with CargoDispatch {
   Cargo._();
   /// Create a new cargo storage
   factory Cargo({CargoModeHolder MODE: CargoMode.MEMORY, Map path}) {
-      print("Initiating a cargo storage with ${MODE} backend");
-      
-      switch(MODE) {
-        case CargoMode.MEMORY:
-          return new MemoryCargo();
-        case CargoMode.LOCAL:
-          return new LocalstorageCargo(window.localStorage);
-        case CargoMode.SESSION:
-          return new LocalstorageCargo(window.sessionStorage);
-        case CargoMode.INDEXDB:
-          if (IndexDbCargo.supported) { 
-            return new IndexDbCargo("dbName", "storeName");
-          } 
-          return new LocalstorageCargo(window.localStorage);
-        default:
-          Logger.root.warning("Error: Unsupported storage backend \"${MODE}\", supported backends on server is: ${CargoMode.MEMORY} and ${CargoMode.LOCAL}");
-      }
-    }
-}
+    print("Initiating a cargo storage with ${MODE} backend");
 
+    switch (MODE) {
+      case CargoMode.MEMORY:
+        return new MemoryCargo();
+      case CargoMode.LOCAL:
+        return new LocalstorageCargo(window.localStorage);
+      case CargoMode.SESSION:
+        return new LocalstorageCargo(window.sessionStorage);
+      case CargoMode.INDEXDB:
+        if (IndexDbCargo.supported) {
+          return new IndexDbCargo("dbName", "storeName");
+        }
+        return new LocalstorageCargo(window.localStorage);
+      default:
+        Logger.root.warning("Error: Unsupported storage backend \"${MODE}\", supported backends on server is: ${CargoMode.MEMORY} and ${CargoMode.LOCAL}");
+    }
+  }
+}

--- a/lib/src/client/cargo_mode.dart
+++ b/lib/src/client/cargo_mode.dart
@@ -1,6 +1,6 @@
 part of cargo_client;
 
-class CargoMode  {
+class CargoMode {
   /// all the cargo modes for the client implementations
   static const MEMORY = const CargoModeHolder('Memory');
   static const LOCAL = const CargoModeHolder('Local');

--- a/lib/src/client/indexdb_impl.dart
+++ b/lib/src/client/indexdb_impl.dart
@@ -3,18 +3,18 @@ part of cargo_client;
 class IndexDbCargo extends Cargo {
   String dbName;
   String storeName;
-  
+
   bool _isOpen;
-  
+
   int count = 0;
-  
+
   List<String> keys = new List<String>();
- 
+
   /// Returns true if IndexedDB is supported on this platform.
   static bool get supported => IdbFactory.supported;
-  
+
   static Map<String, Database> _databases = new Map<String, Database>();
-  
+
   IndexDbCargo(this.dbName, this.storeName) : super._();
 
   dynamic getItemSync(String key, {defaultValue}) {
@@ -22,16 +22,15 @@ class IndexDbCargo extends Cargo {
   }
 
   Future getItem(String key, {defaultValue}) {
-    return _doCommand((ObjectStore store) { 
+    return _doCommand((ObjectStore store) {
       var obj = store.getObject(key);
-      if (obj==null) {
-        if (defaultValue!=null) {
-          setItem(key, defaultValue); 
+      if (obj == null) {
+        if (defaultValue != null) {
+          setItem(key, defaultValue);
         }
         return defaultValue;
       }
-    },
-    'readonly');
+    }, 'readonly');
   }
 
   void setItem(String key, data) {
@@ -40,30 +39,30 @@ class IndexDbCargo extends Cargo {
       this.keys.add(key);
       return store.put(key, data);
     });
-   
+
   }
-  
+
   void add(String key, data) {
     _doCommand((ObjectStore store) {
       store.getObject(key).then((obj) {
         if (obj is List) {
           List list = obj;
           list.add(data);
-          
+
           dispatch(key, list);
           return store.put(key, list);
         }
-        
+
       }, onError: (e) {
         List list = new List();
         list.add(data);
-                
+
         dispatch(key, list);
-        this.keys.add(key);  
+        this.keys.add(key);
         return store.put(key, list);
-      }); 
-    });  
-   
+      });
+    });
+
   }
 
   void removeItem(String key) {
@@ -74,7 +73,7 @@ class IndexDbCargo extends Cargo {
   }
 
   void clear() {
-    _doCommand((ObjectStore store) { 
+    _doCommand((ObjectStore store) {
       store.clear();
       this.keys.clear();
     });
@@ -83,56 +82,50 @@ class IndexDbCargo extends Cargo {
   int length() {
     throw new UnsupportedError('IndexedDB is not supporting length retrieval synchronously');
   }
-  
-  Future _doCommand(Future requestCommand(ObjectStore store),
-               [String txnMode = 'readwrite']) {
-      var completer = new Completer();
-      var trans = _db.transaction(storeName, txnMode);
-      var store = trans.objectStore(storeName);
-      var future = requestCommand(store);
-      return trans.completed.then((_) => future);
+
+  Future _doCommand(Future requestCommand(ObjectStore store), [String txnMode = 'readwrite']) {
+    var completer = new Completer();
+    var trans = _db.transaction(storeName, txnMode);
+    var store = trans.objectStore(storeName);
+    var future = requestCommand(store);
+    return trans.completed.then((_) => future);
   }
 
   Future start() {
     if (!supported) {
-        return new Future.error(
-        new UnsupportedError('IndexedDB is not supported on this platform'));
+      return new Future.error(new UnsupportedError('IndexedDB is not supported on this platform'));
     }
-        
-    return window.indexedDB.open(dbName)
-        .then((Database db) {
-          //print("Newly opened db $dbName has version ${db.version} and stores ${db.objectStoreNames}");
-          if (!db.objectStoreNames.contains(storeName)) {
-            db.close();
-            
-            print('Attempting upgrading $storeName from ${db.version}');
-            
-            return window.indexedDB.open(dbName, version: 1,
-              onUpgradeNeeded: (e) {
-                //print('Upgrading db $dbName to ${db.version + 1}');
-                Database d = e.target.result;
-                d.createObjectStore(storeName);
-              }
-            );
-          } else {
-            //print('The store $storeName exists in $dbName');
-            return db;
-          }
-        })
-        .then((db){
-          _databases[dbName] = db;
-          _isOpen = true;
-          return true;
+
+    return window.indexedDB.open(dbName).then((Database db) {
+      //print("Newly opened db $dbName has version ${db.version} and stores ${db.objectStoreNames}");
+      if (!db.objectStoreNames.contains(storeName)) {
+        db.close();
+
+        print('Attempting upgrading $storeName from ${db.version}');
+
+        return window.indexedDB.open(dbName, version: 1, onUpgradeNeeded: (e) {
+          //print('Upgrading db $dbName to ${db.version + 1}');
+          Database d = e.target.result;
+          d.createObjectStore(storeName);
         });
+      } else {
+        //print('The store $storeName exists in $dbName');
+        return db;
+      }
+    }).then((db) {
+      _databases[dbName] = db;
+      _isOpen = true;
+      return true;
+    });
   }
-  
+
   Map export() {
-     Map values = new Map();
-     for (var key in keys) {
-       values[key] = getItemSync(key);
-     }
-     return values;
-   } 
+    Map values = new Map();
+    for (var key in keys) {
+      values[key] = getItemSync(key);
+    }
+    return values;
+  }
 
   Database get _db => _databases[dbName];
 }

--- a/lib/src/client/memory_impl.dart
+++ b/lib/src/client/memory_impl.dart
@@ -1,5 +1,5 @@
 part of cargo_client;
 
 class MemoryCargo extends MemoryImpl implements Cargo {
-  
+
 }

--- a/lib/src/client/storage_impl.dart
+++ b/lib/src/client/storage_impl.dart
@@ -3,19 +3,19 @@ part of cargo_client;
 class LocalstorageCargo extends Cargo {
   Completer _completer;
   Storage values;
- 
+
   LocalstorageCargo(this.values) : super._() {
     _completer = new Completer();
     _completer.complete();
   }
-  
+
   dynamic getItemSync(String key, {defaultValue}) {
-     _checkDefault(key, defaultValue: defaultValue);
-     return values[key] is String ? JSON.decode(values[key]) : values[key];
-   }
-  
+    _checkDefault(key, defaultValue: defaultValue);
+    return values[key] is String ? JSON.decode(values[key]) : values[key];
+  }
+
   void _checkDefault(String key, {defaultValue}) {
-    if (values[key]==null && defaultValue!=null) {
+    if (values[key] == null && defaultValue != null) {
       setItem(key, defaultValue);
     }
   }
@@ -28,21 +28,21 @@ class LocalstorageCargo extends Cargo {
 
   void setItem(String key, data) {
     values[key] = JSON.encode(data);
-    
+
     dispatch(key, data);
   }
-  
+
   void add(String key, data) {
-      List list = new List(); 
-      if (values.containsKey(key)) {
-        Object obj = JSON.decode(values[key]);
-        if (obj is List) {
-          list = JSON.decode(values[key]);
-        }
+    List list = new List();
+    if (values.containsKey(key)) {
+      Object obj = JSON.decode(values[key]);
+      if (obj is List) {
+        list = JSON.decode(values[key]);
       }
-      _add(list, key, data);
+    }
+    _add(list, key, data);
   }
-    
+
   void _add(List list, String key, data) {
     list.add(data);
 
@@ -60,11 +60,10 @@ class LocalstorageCargo extends Cargo {
   int length() {
     return values.length;
   }
-  
+
   Map export() {
     return values;
-  } 
+  }
 
   Future start() => _completer.future;
 }
-

--- a/lib/src/server/cargo.dart
+++ b/lib/src/server/cargo.dart
@@ -5,12 +5,12 @@ abstract class Cargo extends CargoBase with CargoDispatch {
   /// Create a new cargo storage
   factory Cargo({CargoModeHolder MODE: CargoMode.MEMORY, conf}) {
     print("Initiating a cargo storage with ${MODE} backend");
-    
+
     switch(MODE) {
       case CargoMode.MEMORY:
         return new MemoryCargo();
       case CargoMode.FILE:
-        return new FileBackend(conf!=null ? conf["path"] : "");
+        return new FileCargo(conf!=null ? conf["path"] : "");
       default:
         Logger.root.warning("Error: Unsupported storage backend \"${MODE}\", supported backends on server is: ${CargoMode.MEMORY} and ${CargoMode.FILE}");
     }

--- a/lib/src/server/cargo.dart
+++ b/lib/src/server/cargo.dart
@@ -6,14 +6,13 @@ abstract class Cargo extends CargoBase with CargoDispatch {
   factory Cargo({CargoModeHolder MODE: CargoMode.MEMORY, conf}) {
     print("Initiating a cargo storage with ${MODE} backend");
 
-    switch(MODE) {
+    switch (MODE) {
       case CargoMode.MEMORY:
         return new MemoryCargo();
       case CargoMode.FILE:
-        return new FileCargo(conf!=null ? conf["path"] : "");
+        return new FileCargo(conf != null ? conf["path"] : "");
       default:
         Logger.root.warning("Error: Unsupported storage backend \"${MODE}\", supported backends on server is: ${CargoMode.MEMORY} and ${CargoMode.FILE}");
     }
   }
 }
-

--- a/lib/src/server/cargo_mode.dart
+++ b/lib/src/server/cargo_mode.dart
@@ -1,8 +1,8 @@
 part of cargo_server;
 
-class CargoMode  {
-/// all the cargo modes for the server implementations
+class CargoMode {
+  /// all the cargo modes for the server implementations
   static const MEMORY = const CargoModeHolder('Memory');
   static const FILE = const CargoModeHolder('File');
-  
+
 }

--- a/lib/src/server/file_impl.dart
+++ b/lib/src/server/file_impl.dart
@@ -1,6 +1,6 @@
 part of cargo_server;
 
-class FileBackend extends Cargo {
+class FileCargo extends Cargo {
   Completer _completer;
   final Logger log = new Logger('JsonStorage');
   String pathToStore;
@@ -9,7 +9,7 @@ class FileBackend extends Cargo {
 
   Map map;
 
-  FileBackend (String dir) : super._() {
+  FileCargo (String dir) : super._() {
     pathToStore = Platform.script.resolve(dir).toFilePath();
     _completer = new Completer();
 

--- a/lib/src/server/file_impl.dart
+++ b/lib/src/server/file_impl.dart
@@ -9,7 +9,7 @@ class FileCargo extends Cargo {
 
   Map map;
 
-  FileCargo (String dir) : super._() {
+  FileCargo(String dir) : super._() {
     pathToStore = Platform.script.resolve(dir).toFilePath();
     _completer = new Completer();
 
@@ -28,7 +28,7 @@ class FileCargo extends Cargo {
     }
   }
 
-  dynamic getItemSync(String key,  {defaultValue}) {
+  dynamic getItemSync(String key, {defaultValue}) {
     if (keys.contains(key)) {
       var uriKey = new Uri.file(pathToStore).resolve("$key.json");
       var file = new File(uriKey.toFilePath());
@@ -42,7 +42,7 @@ class FileCargo extends Cargo {
     return defaultValue;
   }
 
-  Future getItem(String key,  {defaultValue}) {
+  Future getItem(String key, {defaultValue}) {
     Completer complete = new Completer();
 
     if (keys.contains(key)) {
@@ -67,10 +67,10 @@ class FileCargo extends Cargo {
 
     return complete.future;
   }
-  
+
   void _setDefaultValue(String key, defaultValue) {
-    if (defaultValue!=null) {
-        setItem(key, defaultValue); 
+    if (defaultValue != null) {
+      setItem(key, defaultValue);
     }
   }
 
@@ -89,28 +89,28 @@ class FileCargo extends Cargo {
     }
     dispatch(key, data);
   }
-  
+
   void add(String key, data) {
-       List list = new List(); 
-       if (keys.contains(key)) {
-         Object obj = getItem(key).then((obj) {
-           if (obj is List) {
-              list = obj;
-              _add(list, key, data);
-           }
-         });
-       } else {
-         _add(list, key, data);
-       }
-   }
-     
-   void _add(List list, String key, data) {
-     list.add(data);
+    List list = new List();
+    if (keys.contains(key)) {
+      Object obj = getItem(key).then((obj) {
+        if (obj is List) {
+          list = obj;
+          _add(list, key, data);
+        }
+      });
+    } else {
+      _add(list, key, data);
+    }
+  }
 
-     setItem(key, list);
-   }
+  void _add(List list, String key, data) {
+    list.add(data);
 
-  void _writeFile (File file, key, data) {
+    setItem(key, list);
+  }
+
+  void _writeFile(File file, key, data) {
     file.writeAsStringSync(JSON.encode(data));
   }
 
@@ -122,31 +122,30 @@ class FileCargo extends Cargo {
       log.info("item $key deleted successfully");
     });
   }
-  
+
   Map export() {
     Map values = new Map();
     for (var key in keys) {
       values[key] = getItemSync(key);
     }
     return values;
-  } 
+  }
 
   void clear() {
     Directory dir = new Directory(pathToStore);
 
-    dir.list(recursive: true, followLinks: false)
-        .listen((FileSystemEntity entity) {
-          var path = entity.path;
-          if (path.indexOf(".json") > 1) {
-            log.info("deleting $path");
-            var file = new File(path);
-            try {
-              file.deleteSync();
-            } on Exception catch(e) {
-              print('Unknown exception: $e');
-            }
-          }
-        });
+    dir.list(recursive: true, followLinks: false).listen((FileSystemEntity entity) {
+      var path = entity.path;
+      if (path.indexOf(".json") > 1) {
+        log.info("deleting $path");
+        var file = new File(path);
+        try {
+          file.deleteSync();
+        } on Exception catch (e) {
+          print('Unknown exception: $e');
+        }
+      }
+    });
     keys.clear();
   }
 
@@ -156,20 +155,18 @@ class FileCargo extends Cargo {
 
   void _readInKeys() {
     Directory dir = new Directory(pathToStore);
-        dir.list(recursive: true, followLinks: false)
-        .listen((FileSystemEntity entity) {
-              var path = entity.path;
-              
-              if (path.indexOf(".json") > 1) {
-                var fileName = path.split('\\').last; 
-                fileName = fileName.replaceAll(".json", '');
-                keys.add(fileName.toString());
-              }
-            }).onDone(() {
-                _completer.complete();
-            });
+    dir.list(recursive: true, followLinks: false).listen((FileSystemEntity entity) {
+      var path = entity.path;
+
+      if (path.indexOf(".json") > 1) {
+        var fileName = path.split('\\').last;
+        fileName = fileName.replaceAll(".json", '');
+        keys.add(fileName.toString());
+      }
+    }).onDone(() {
+      _completer.complete();
+    });
   }
 
   Future start() => _completer.future;
 }
-

--- a/lib/src/server/memory_impl.dart
+++ b/lib/src/server/memory_impl.dart
@@ -1,7 +1,7 @@
 part of cargo_server;
 
 class MemoryCargo extends MemoryImpl implements Cargo {
-  
+
   Cargo exportToFileStorage(String path) {
     Cargo storage = new Cargo(MODE: CargoMode.FILE, conf: {"path": path});
     storage = copyTo(storage);

--- a/test/client/memory_test.dart
+++ b/test/client/memory_test.dart
@@ -3,16 +3,15 @@ import 'package:cargo/cargo_client.dart';
 
 void main() {
   // First tests!
-  Cargo storage = new Cargo(MODE: CargoMode.MEMORY);
+  MemoryCargo storage = new Cargo(MODE: CargoMode.MEMORY);
 
   storage.start().then((_) {
     test('test basic memory storage', () {
-        storage.setItem("data", {"data": "data"});
+      storage.setItem("data", {"data": "data"});
 
-        var data = storage.getItemSync("data");
-        expect(data["data"], "data");
-        expect(storage.length(), 1);
+      var data = storage.getItemSync("data");
+      expect(data["data"], "data");
+      expect(storage.length(), 1);
     });
   });
 }
-

--- a/test/server/file_access_test.dart
+++ b/test/server/file_access_test.dart
@@ -3,7 +3,7 @@ import 'package:cargo/cargo_server.dart';
 
 void main() {
   // First tests!
-  Cargo storage = new Cargo(MODE: CargoMode.FILE, conf: {"path": "./"});
+  FileCargo storage = new Cargo(MODE: CargoMode.FILE, conf: {"path": "./"});
 
   storage.start().then((_) {
     test('test basic json storage access', () {

--- a/test/server/file_access_test.dart
+++ b/test/server/file_access_test.dart
@@ -3,16 +3,15 @@ import 'package:cargo/cargo_server.dart';
 
 void main() {
   // First tests!
-  Cargo storage = new Cargo(MODE: CargoMode.FILE, conf: { "path" : "../store/"});
+  Cargo storage = new Cargo(MODE: CargoMode.FILE, conf: {"path": "./"});
 
   storage.start().then((_) {
     test('test basic json storage access', () {
-           storage.clear();
-           storage["someValue"] = {"value": "go"};
+      storage.clear();
+      storage["someValue"] = {"value": "go"};
 
-           expect(storage["someValue"], {"value": "go"});
-           expect(storage.length(), 1);
-       });
+      expect(storage["someValue"], {"value": "go"});
+      expect(storage.length(), 1);
+    });
   });
 }
-

--- a/test/server/file_test.dart
+++ b/test/server/file_test.dart
@@ -3,16 +3,16 @@ import 'package:cargo/cargo_server.dart';
 
 void main() {
   // First tests!
-  Cargo storage = new Cargo(MODE: CargoMode.FILE, conf: { "path" : "../store/"});
+  Cargo storage = new Cargo(MODE: CargoMode.FILE, conf: {"path": "./"});
 
   storage.start().then((_) {
     test('test basic json storage', () {
-        storage.clear();
-        storage.setItem("data", {"data": "data"});
+      storage.clear();
+      storage.setItem("data", {"data": "data"});
 
-        var data = storage.getItemSync("data");
-        expect(data["data"], "data");
-        expect(storage.length(), 1);
+      var data = storage.getItemSync("data");
+      expect(data["data"], "data");
+      expect(storage.length(), 1);
     });
 
     Map asyncData = {"as": "go"};
@@ -25,4 +25,3 @@ void main() {
     });
   });
 }
-

--- a/test/server/file_test.dart
+++ b/test/server/file_test.dart
@@ -3,7 +3,7 @@ import 'package:cargo/cargo_server.dart';
 
 void main() {
   // First tests!
-  Cargo storage = new Cargo(MODE: CargoMode.FILE, conf: {"path": "./"});
+  FileCargo storage = new Cargo(MODE: CargoMode.FILE, conf: {"path": "./"});
 
   storage.start().then((_) {
     test('test basic json storage', () {

--- a/test/server/memory_test.dart
+++ b/test/server/memory_test.dart
@@ -4,7 +4,7 @@ import 'package:cargo/cargo_server.dart';
 void main() {
   // First tests!
   MemoryCargo storage = new Cargo(MODE: CargoMode.MEMORY);
-  Cargo fileStorage = new Cargo(MODE: CargoMode.FILE, conf: {"path": "./"});
+  FileCargo fileStorage = new Cargo(MODE: CargoMode.FILE, conf: {"path": "./"});
 
   storage.start().then((_) {
     test('test basic memory storage', () {

--- a/test/server/memory_test.dart
+++ b/test/server/memory_test.dart
@@ -8,9 +8,7 @@ void main() {
 
   storage.start().then((_) {
     test('test basic memory storage', () {
-      storage.setItem("data", {
-        "data": "data"
-      });
+      storage.setItem("data", {"data": "data"});
 
       var data = storage.getItemSync("data");
       expect(data["data"], "data");


### PR DESCRIPTION
I think that server-side FileBackend should be renamed to FileCargo because of naming conventions.

And I also changed the directory to store temporary files from tests to the same directory where the tests are because some people can have problems with access rights and creating directories from tests.
